### PR TITLE
Api/sort holdings on update

### DIFF
--- a/models/portfolios.js
+++ b/models/portfolios.js
@@ -153,7 +153,7 @@ const hasHolding = (owner, _id, ticker) => {
  * @param    {String}   _id      Portfolio _id
  * @param    {String}   ticker   Holding's ticker symbol
  * @param    {Number}   qty      Qty of shares owned
- * @returns  {Object}            Updated portfolio
+ * @returns  {Object}            Updated portfolio; holdings sorted by ticker
 */
 const addHolding = ({owner, _id}, {ticker, qty}) => {
   const collection = db.get().collection('portfolios');
@@ -167,11 +167,14 @@ const addHolding = ({owner, _id}, {ticker, qty}) => {
   const updates = {
     '$push': {
       holdings : {
-        _id       : ObjectID(),
-        ticker    : sanitize(ticker),
-        createdAt : now,
-        updatedAt : now,
-        qty
+        $each: [{
+          _id       : ObjectID(),
+          ticker    : sanitize(ticker),
+          createdAt : now,
+          updatedAt : now,
+          qty
+        }],
+        $sort: { ticker: 1 }
       }
     }
   };

--- a/utils/validateTickers.js
+++ b/utils/validateTickers.js
@@ -5,6 +5,6 @@
  * @returns   {Boolean}           True if ticker matches pattern
 */
 module.exports = (ticker) => {
-  const rex = /^[0-9A-Z]{5}$/;
+  const rex = /^[0-9A-Z]{4,5}$/;
   return typeof ticker === 'string' && rex.test(ticker);
 };


### PR DESCRIPTION
Two updates:

1.  The regex to validate tickers was checking for exactly 5 characters. Many tickers have fewer than 5 characters. Updated regex quantifier to match when given 4 or 5 characters. This is a monkey patch for now - there are tickers with fewer than 4 characters  (GE for example). Will need more robust validation in the future.

2. When adding a holdings, the portfolios model uses a `$push` update operator to add a holding object to a portfolio's array of `holdings`. Previously we were just pushing to the end of the `holdings` array. Now we sort the holdings by `ticker` ascending during the `$push` operations.