### PR TITLE
Api/tweak validator

### DIFF
--- a/models/portfolios.js
+++ b/models/portfolios.js
@@ -2,12 +2,13 @@
 
 /* ================================= SETUP ================================= */
 
-const sanitize = require('../utils/sanitizeMongoQuery');
-const ObjectID = require('mongodb').ObjectID;
-const db       = require('../db');
+const ObjectID  = require('mongodb').ObjectID;
+const db        = require('../db');
 
-const required = require('../utils/requiredParam');
-const validate = require('../utils/validateModelParams');
+const sanitize  = require('../utils/sanitizeMongoQuery');
+const required  = require('../utils/requiredParam');
+const Validator = require('../utils/validateModelParams');
+const validate  = new Validator();
 
 
 /* ============================ PUBLIC METHODS ============================= */
@@ -19,7 +20,7 @@ const validate = require('../utils/validateModelParams');
 */
 const getAll = (owner = required('owner')) => {
 
-  validate([{ type: 'owner', value: owner }]);
+  validate.check([{ type: 'owner', value: owner }]);
 
   const collection = db.get().collection('portfolios');
   const target     = { owner };
@@ -43,7 +44,7 @@ const getOne = (
   _id   = required('_id')
 ) => {
 
-  validate([{ type: 'owner', value: owner }, { type: '_id', value : _id }]);
+  validate.check([{ type: 'owner', value: owner }, { type: '_id', value : _id }]);
 
   const collection = db.get().collection('portfolios');
   const target     = {
@@ -73,7 +74,7 @@ const create = ({
 
   notes = notes || '';
 
-  validate([
+  validate.check([
     { type: 'owner', value: owner },
     { type: 'name',  value: name },
     { type: 'notes', value: notes }
@@ -110,7 +111,7 @@ const update = (
   { name, notes }
 ) => {
 
-  validate([
+  validate.check([
     { type: 'owner', value: owner },
     { type: '_id',   value: _id },
     { type: 'name',  value: name },
@@ -148,7 +149,7 @@ const deletePortfolio = (
   _id   = required('_id')
 ) => {
 
-  validate([
+  validate.check([
     { type: 'owner', value: owner },
     { type: '_id',   value: _id }
   ]);
@@ -178,7 +179,7 @@ const hasHolding = (
   ticker = required('ticker')
 ) => {
 
-  validate([
+  validate.check([
     { type: 'owner',  value: owner },
     { type: '_id',    value: _id },
     { type: 'ticker', value: ticker }
@@ -213,7 +214,7 @@ const addHolding = (
   {ticker = required('ticker'), qty = required('qty')}
 ) => {
 
-  validate([
+  validate.check([
     { type: 'owner',  value: owner },
     { type: '_id',    value: _id },
     { type: 'ticker', value: ticker },
@@ -272,7 +273,7 @@ const updateHolding = (
   qty = required('qty')
 ) => {
 
-  validate([
+  validate.check([
     { type: 'owner',  value: owner },
     { type: 'pfloId', value: pfloId },
     { type: 'hldgId', value: hldgId },
@@ -316,7 +317,7 @@ const deleteHolding = ({
   hldgId = required('hldgId')
 }) => {
 
-  validate([
+  validate.check([
     { type: 'owner',  value: owner },
     { type: 'pfloId', value: pfloId },
     { type: 'hldgId', value: hldgId }

--- a/test/models/portfolios_model.test.js
+++ b/test/models/portfolios_model.test.js
@@ -120,7 +120,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.getAll(666);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -174,7 +174,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.getOne(666, dummyPflos[0]._id);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -192,7 +192,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.getOne(pfloOwner, 666);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "_id"');
+        assert.equal(err.message, 'Validation Error: Invalid "_id": 666');
       }
     });
 
@@ -267,7 +267,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.create(badDoc);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -287,7 +287,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.create(badDoc);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "name"');
+        assert.equal(err.message, 'Validation Error: Invalid "name": 666');
       }
     });
 
@@ -297,7 +297,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.create(badDoc);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "notes"');
+        assert.equal(err.message, 'Validation Error: Invalid "notes": 666');
       }
     });
 
@@ -377,7 +377,7 @@ describe('Portfolios model', () => {
         const result    = await Portfolios.update(badTarget, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -399,7 +399,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.update(badDoc, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "_id"');
+        assert.equal(err.message, 'Validation Error: Invalid "_id": 666');
       }
     });
 
@@ -410,7 +410,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.update(badDoc, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "name"');
+        assert.equal(err.message, 'Validation Error: Invalid "name": 666');
       }
     });
 
@@ -421,7 +421,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.update(badDoc, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "notes"');
+        assert.equal(err.message, 'Validation Error: Invalid "notes": 666');
       }
     });
 
@@ -468,7 +468,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.deletePortfolio(666, pfloID1);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -486,7 +486,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.deletePortfolio(pfloOwner, 666);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "_id"');
+        assert.equal(err.message, 'Validation Error: Invalid "_id": 666');
       }
     });
 
@@ -534,7 +534,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.hasHolding(666, pfloID1, 'MSFT');
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
 
     });
@@ -554,7 +554,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.hasHolding(pfloOwner, 666, 'MSFT');
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "_id"');
+        assert.equal(err.message, 'Validation Error: Invalid "_id": 666');
       }
 
     });
@@ -574,7 +574,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.hasHolding(pfloOwner, pfloID1, 666);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "ticker"');
+        assert.equal(err.message, 'Validation Error: Invalid "ticker": 666');
       }
 
     });
@@ -652,7 +652,7 @@ describe('Portfolios model', () => {
         const result  = await Portfolios.addHolding(pflo, holding);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -674,7 +674,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.addHolding(pflo, holding);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "_id"');
+        assert.equal(err.message, 'Validation Error: Invalid "_id": 666');
       }
     });
 
@@ -697,7 +697,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.addHolding(pflo, holding);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "ticker"');
+        assert.equal(err.message, 'Validation Error: Invalid "ticker": 666');
       }
     });
 
@@ -719,7 +719,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.addHolding(pflo, holding);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "qty"');
+        assert.equal(err.message, 'Validation Error: Invalid "qty": 666');
       }
     });
 
@@ -782,7 +782,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.updateHolding(query, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -804,7 +804,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.updateHolding(query, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "pfloId"');
+        assert.equal(err.message, 'Validation Error: Invalid "pfloId": 666');
       }
     });
 
@@ -826,7 +826,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.updateHolding(query, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "hldgId"');
+        assert.equal(err.message, 'Validation Error: Invalid "hldgId": 666');
       }
     });
 
@@ -848,7 +848,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.updateHolding(query, update);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "qty"');
+        assert.equal(err.message, 'Validation Error: Invalid "qty": 1234');
       }
     });
 
@@ -907,7 +907,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.deleteHolding(query);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "owner"');
+        assert.equal(err.message, 'Validation Error: Invalid "owner": 666');
       }
     });
 
@@ -927,7 +927,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.deleteHolding(query);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "pfloId"');
+        assert.equal(err.message, 'Validation Error: Invalid "pfloId": 666');
       }
     });
 
@@ -947,7 +947,7 @@ describe('Portfolios model', () => {
         const result = await Portfolios.deleteHolding(query);
         if (result) { throw new Error('this block should not execute'); }
       } catch (err) {
-        assert.equal(err.message, 'Invalid parameter "hldgId"');
+        assert.equal(err.message, 'Validation Error: Invalid "hldgId": 666');
       }
     });
 

--- a/test/utils/validateModelParams.test.js
+++ b/test/utils/validateModelParams.test.js
@@ -1,0 +1,70 @@
+/* globals describe beforeEach it */
+
+/* ================================= SETUP ================================= */
+
+const { assert } = require('chai');
+const Validator  = require('../../utils/validateModelParams');
+
+const testSchema = {
+  string : (val) => typeof val === 'string',
+  number : (val) => typeof val === 'number'
+};
+
+
+/* ================================= TESTS ================================= */
+
+describe('Utility: validateModelParams', () => {
+
+  let validator;
+
+  beforeEach(() => {
+    validator = new Validator(testSchema);
+  });
+  
+
+  it('should be a function', () => {
+    assert.isFunction(Validator);
+  });
+
+  it('should be a constructor', () => {
+    assert.instanceOf(validator, Validator);
+  });
+
+  it('instances should have default "schema" property if not passed', () => {
+    const defaultValidator = new Validator();
+    assert.isObject(defaultValidator.schema);
+    assert.isNotEmpty(defaultValidator.schema);
+  });
+
+  it('instances should have custom "schema" property if passed', () => {
+    assert.isObject(validator.schema);
+    assert.hasAllKeys(validator.schema, ['string', 'number']);
+  });
+
+  it('instances should have a "check" method', () => {
+    assert.isFunction(validator.check);
+  });
+
+  it('instances should return true for valid string "yay"', () => {
+    assert.isTrue(validator.check([{ type: 'string', value: 'yay' }]));
+  });
+
+  it('instances should return true for valid number 666', () => {
+    assert.isTrue(validator.check([{ type: 'number', value: 666 }]));
+  });
+
+  it('instances should throw exception for invalid string', () => {
+    const call = function() {
+      validator.check([{ type: 'string', value: 666 }]);
+    };
+    assert.throws(call, 'Invalid "string": 666');
+  });
+
+  it('instances should throw exception for invalid number', () => {
+    const call = function() {
+      validator.check([{ type: 'number', value: 'bananas' }]);
+    };
+    assert.throws(call, 'Invalid "number": bananas');
+  });
+
+});

--- a/test/utils/validateQty.test.js
+++ b/test/utils/validateQty.test.js
@@ -8,7 +8,7 @@ const validateQty = require('../../utils/validateQty');
 
 /* ================================= TESTS ================================= */
 
-describe('Utility: validateNames', () => {
+describe('Utility: validateQty', () => {
 
   it('should be a function', () => {
     assert.isFunction(validateQty);

--- a/utils/validateModelParams.js
+++ b/utils/validateModelParams.js
@@ -4,7 +4,7 @@ const validateNames     = require('./validateNames');
 const validateNotes     = require('./validateNotes');
 const validateQty       = require('./validateQty');
 
-const schema = {
+const defaultSchema = {
   _id    : validateObjectIds,
   hldgId : validateObjectIds,
   owner  : validateObjectIds,
@@ -15,23 +15,33 @@ const schema = {
   qty    : validateQty
 };
 
-/** Wholesale Model Data Validation Utility
- *  Loops over array of params, checking each against schema
- * 
- *  @param   {Array}  paramsList   Array of arrays of key value pairs
- *  @throws  {Error}               Error specific to failed check
- *  @returns {Boolean}             Returns true if all params are valid
-*/
-module.exports = function(paramsList) {
 
-  for (let i = 0; i < paramsList.length; i += 1) {
-    let type  = paramsList[i].type;
-    let input = paramsList[i].value;
-    if (!schema[type](input)) {
-      throw new Error(`Invalid parameter "${type}"`);
-    }
+module.exports = class ModelParamValidator {
+  
+  /** Instantiates validators with passed or default schema
+   * 
+   *  @param   {Object}   schema   Optional custom schema object
+  */
+  constructor(schema = defaultSchema) {
+    this.schema = schema;
   }
-
-  return true;
+  
+  /** Wholesale Model Data Validation Utility
+   *  Loops over array of params, checking each against schema
+   * 
+   *  @param   {Array}    params   Array of arrays of key value pairs
+   *  @throws  {Error}             Error specific to failed check
+   *  @returns {Boolean}           Returns true if all params are valid
+  */
+  check(params) {
+    for (let param of params) {
+      let type  = param.type;
+      let value = param.value;
+      if (!this.schema[type](value)) {
+        throw new Error(`Validation Error: Invalid "${type}": ${value}`);
+      }
+    }
+    return true;
+  }
 
 };


### PR DESCRIPTION
Refactors the utility `validateModelParams.js`. It previously depended on multiple external modules and was difficult to unit test. It now exports a class whose constructor takes an optional `schema` parameter. This allows tests to instantiate a new validator with their own test schemas, while permitting production code to instantiate with the default schema.

Additionally, thrown error messages are more verbose & more specific. This required updates to most of the tests in `portfolios_model.test.js`.