### PR TITLE
Api now requires bearer tokens

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -14,7 +14,7 @@ const Users       = require('../models/users');
  * Example: POST >> /auth/register
  * Secured: No
  * Expects: username & passwords from http POST request body
- * Returns: JWT (String)
+ * Returns: object w/success {Boolean} and token {String}
 */
 const register = async (req, res, next) => {
 
@@ -46,7 +46,10 @@ const register = async (req, res, next) => {
       username : result.username,
       _id      : result._id
     }))
-    .then(token => res.status(200).json(token))
+    .then(token => res.status(200).json({
+      success : true,
+      token   : token
+    }))
     .catch(err  => next(err));
   
 };
@@ -57,7 +60,7 @@ const register = async (req, res, next) => {
  * Example: POST >> /auth/login
  * Secured: No
  * Expects: username and password from http POST request body
- * Returns: JWT (String)
+ * Returns: object w/success {Boolean} and token {String}
 */
 const login = async (req, res, next) => {
 
@@ -79,7 +82,10 @@ const login = async (req, res, next) => {
   }
 
   return generateJwt({_id: user._id, username: user.username})
-    .then(token => res.status(200).json(token))
+    .then(token => res.status(200).json({
+      success : true,
+      token   : token
+    }))
     .catch(err  => next(err));
 
 };

--- a/middleware/verifyJWT.js
+++ b/middleware/verifyJWT.js
@@ -5,13 +5,19 @@
 const jwt = require('jsonwebtoken');
 
 module.exports = (req, res, next) => {
-  const token = req.headers.authorization;
-  const secret = process.env.JWT_SECRET;
+  const secret     = process.env.JWT_SECRET;
+  const authHeader = req.headers.authorization;
+  const headerRex  = /^Bearer\s{1}[\w\-.]+$/;
 
-  // fail if missing required pieces
-  if (!token || !secret) {
+  if (!authHeader) {
     return next(new Error('Missing components for JWT verification'));
   }
+
+  if (!headerRex.test(authHeader)) {
+    return next(new Error('Expected Authorization header: "Bearer <token>"'));
+  }
+  
+  const token = authHeader.split(' ')[1];
 
   jwt.verify(token, secret, (err, decoded) => {
     if (err) {

--- a/test/controllers/auth.test.js
+++ b/test/controllers/auth.test.js
@@ -87,7 +87,7 @@ describe('Authentication controller', function() {
     const { resData } = await this.controller.register(req, res);
 
     expect(resData.status).to.eql(200);
-    expect(resData.json.split('.').length).to.eql(3);
+    expect(resData.json.token.split('.').length).to.eql(3);
   });
 
 
@@ -149,7 +149,7 @@ describe('Authentication controller', function() {
     const { resData } = await this.controller.login(req, res);
 
     expect(resData.status).to.eql(200);
-    expect(resData.json.split('.').length).to.eql(3);
+    expect(resData.json.token.split('.').length).to.eql(3);
   });
 
 


### PR DESCRIPTION
Clients need to pass Authorization headers in this format:

```
Bearer asd9f87asdf897asdf897adf.98asdf98asdf98asdf.987asdf987asdf987asdf
```